### PR TITLE
Revert publish action to mkdocs-material default

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,5 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install mkdocs-material
-      - name: Deploy to www.energy-modelling-ireland.github.io
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git remote rm origin
-          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/energy-modelling-ireland/energy-modelling-ireland.github.io.git"
-          mkdocs gh-deploy --force
+      - run: mkdocs gh-deploy --force
         


### PR DESCRIPTION
As efforts to deploy this repo to the https://github.com/energy-modelling-ireland/energy-modelling-ireland.github.io
failed... Instead link to this website from the homepage of this other website
See https://squidfunk.github.io/mkdocs-material/publishing-your-site/