### PR TITLE
Remove categorisation of tools by author

### DIFF
--- a/docs/Tools.md
+++ b/docs/Tools.md
@@ -1,23 +1,13 @@
 # Tools
 
-## [Aachen University](https://www.ebc.eonerc.rwth-aachen.de/go/id/dmzz/?lidx=1)
-
-- [TEASER](https://github.com/RWTH-EBC/TEASER) - allows fast generation of archetype buildings (via `TABULA` typologies) with low input requirements and the export of individual Modelica dynamic simulation models. 
-
-## [codema-dev](https://github.com/codema-dev)
-
-- [cer-smart-meter-trials-2009-2011](https://github.com/codema-dev/cer-smart-meter-trials-2009-2011) - simplifies querying the `CER Smart Meter Trials 2009-2011` datasets via `prefect`, `dask`, `pandas` and `Google Colaboratory`
+- [archetypal](https://github.com/samuelduchesne/archetypal) - retrieve, construct, simulate, convert and analyse building simulation templates.  Includes a `tabula_api_request` function to GET TABULA data.
 
 - [berpublicsearch](https://github.com/codema-dev/berpublicsearch) - simplifies querying the SEAI's `BER Public search` database with `dask` and `Google Colaboratory`
 
-## [EnergieID](https://github.com/EnergieID)
+- [cer-smart-meter-trials-2009-2011](https://github.com/codema-dev/cer-smart-meter-trials-2009-2011) - simplifies querying the `CER Smart Meter Trials 2009-2011` datasets via `prefect`, `dask`, `pandas` and `Google Colaboratory`
 
 - [entsoe-py](https://github.com/EnergieID/entsoe-py) - Python client for the ENTSO-E API (european network of transmission system operators for electricity) 
 
-## [gboeing](https://github.com/gboeing)
-
 - [osmnx](https://github.com/gboeing/osmnx) - Python for street networks. Retrieve, model, analyze, and visualize street networks and other spatial data from OpenStreetMap. 
 
-## [samuelduchesne](https://github.com/samuelduchesne)
-
-- [archetypal](https://github.com/samuelduchesne/archetypal) - retrieve, construct, simulate, convert and analyse building simulation templates.  Includes a `tabula_api_request` function to GET TABULA data.
+- [TEASER](https://github.com/RWTH-EBC/TEASER) - allows fast generation of archetype buildings (via `TABULA` typologies) with low input requirements and the export of individual Modelica dynamic simulation models. 


### PR DESCRIPTION
Most authors have written one tool and so it's better to
sort them by larger groupings such as Python or E+ or
electricity etc. TBC