### PR TITLE
Remove ESB Demand Capacity Availability Map

### DIFF
--- a/docs/Data-Sources.md
+++ b/docs/Data-Sources.md
@@ -138,13 +138,10 @@
 - [European Network of Transmission System Operators for Electricity ENTSO-E](https://www.entsoe.eu/) - central collection and publication of electricity generation, transportation and consumption data and information for the pan-European market.
     - See [entsoe-py](Tools.md)
 
-- [ESB Availability Capacity Map: Demand & Generation](https://www.esbnetworks.ie/new-connections/generator-connections/network-capacity-map) - contains capacity information on all our 3-phase LV, MV and HV DSO substations. It provides an interface that enables the easy identification of potential transformer capacity in the vicinity of your site. *An excel file is available to download from the download section on this page.*
+- [ESB Availability Capacity Map: Demand & Generation](https://www.esbnetworks.ie/network-capacity-map) - contains capacity information on all our 3-phase LV, MV and HV DSO substations. It provides an interface that enables the easy identification of potential transformer capacity in the vicinity of your site. *An excel file is available to download from the download section on this page.*
 
 - [ESB Publications](https://www.esbnetworks.ie/tns/publications)
     - [38kV & 110kV Station Special Load Readings 2019/2020](https://zenodo.org/record/4446588) (converted to xlsx) - a coincident set of measurements of simultaneous load for all distribution stations. *Availability Capacity Map provides station locations, demand & capacities.* 
-
-- [ESB Station Demand Availability Map](https://www.esbnetworks.ie/demand-availability-capacity-map) - gives an indication of the available transformer capacity at primary substations (MV & 38kV).
-    - [MapDetailsDemand.xlsx](https://zenodo.org/record/4495334) - stations linked to locations & capacity availablity extracted from capacity map.
 
 - [Openstreetmaps overpass-turbo](https://overpass-turbo.eu/) - download **electricity** data from [Openstreetmaps](https://www.openstreetmap.org) by selecting [Wizard](https://wiki.openstreetmap.org/wiki/Overpass_turbo/Wizard) and entering one of the following [tags](https://taginfo.openstreetmap.org/):
     - [power](https://taginfo.openstreetmap.org/keys/power) - "for marking and tagging facilities for the generation and distribution of electrical power."

--- a/docs/Webtools-&-Webmaps.md
+++ b/docs/Webtools-&-Webmaps.md
@@ -10,9 +10,7 @@
 
 ## ESB
 
-- [Availability Capacity Map](https://www.esbnetworks.ie/new-connections/generator-connections/network-capacity-map) - provides an indication of the available transformer capacity at substations.  Includes capacity information on all our 3-phase LV, MV and HV DSO substations.
-
-- [Demand Availability Capacity Map](https://www.esbnetworks.ie/demand-availability-capacity-map) - provides an indication of the available transformer capacity at substations .
+- [Availability Capacity Map](https://www.esbnetworks.ie/network-capacity-map) - provides an indication of the available transformer capacity at substations.  Includes capacity information on all our 3-phase LV, MV and HV DSO substations.
 
 - [Electric Vehicle Charge Point Map](https://esb.ie/ecars/charge-point-map)
 


### PR DESCRIPTION
Has been replaced by https://www.esbnetworks.ie/network-capacity-map